### PR TITLE
Fautes de frappe

### DIFF
--- a/R/Rayonnement.R
+++ b/R/Rayonnement.R
@@ -38,10 +38,10 @@ Rayonnement <- function(shp, dem, buffer=100) {
     st_transform(4326) %>%
     st_coordinates()
   # ------- Decoupage raster
-  crs(mnt) = st_crs(shp)$proj4string
+  crs(dem) = st_crs(shp)$proj4string
   dem = crop(dem, as(shp1, "Spatial"))
   # ------- Parametres
-  demm = raster:::as.matrix(dem) # transformation du MNT en matrice
+  demm = raster::as.matrix(dem) # transformation du MNT en matrice
   dl = res(dem)[1]
   height = mean(demm)
   visibility=40


### PR DESCRIPTION
Correction d'une erreur de nom de variable : mnt à la place de dem
Correction raster::: au lieu de raster::